### PR TITLE
Fix parentheses position for logical operations.

### DIFF
--- a/bqx/parts.py
+++ b/bqx/parts.py
@@ -117,7 +117,9 @@ class Column(Comparable, Alias):
             if isinstance(other, str):
                 other = repr(other)
 
-            if op != '=':
+            if op == 'AND' or op == 'OR':
+                t = '(%s) %s %s'
+            elif op != '=':
                 t = '(%s %s %s)'
             else:
                 t = '%s %s %s'

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -57,3 +57,5 @@ def test_complex_calc():
     assert str(column_as + column_as + column_as + column_as) == '(((col + col) + col) + col)'
     assert str(column_as + column_as - column_as * column_as / column_as) == '((col + col) - ((col * col) / col))'
     assert str(column_as / (column_as * 39)) == '(col / (col * 39))'
+    assert str((column_as == 5) & (column_as >= 39)) == '(col = 5) AND (col >= 39)'
+    assert str((column_as == 5) | (column_as >= 39)) == '(col = 5) OR (col >= 39)'


### PR DESCRIPTION
Right now expression `Q().SELECT(campaign_name).FROM(table).WHERE((campaign_name == 'Some campaign') & (value > 20))` generates a query like this:

``` sql
SELECT campaign_name
FROM table
WHERE (campaign_name = 'Some campaign' AND (value > 20))
```

This patch changes `WHERE` clause to `WHERE (campaign_name = 'Some campaign') AND (value > 20)`
