### PR TITLE
prepare for releasing v0.4.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 BQX Changelog
 =============
 
+Version 0.4.2
+-------------
+
+Update description: This project is archived and no longer maintained.
+
 
 Version 0.0.1
 -------------

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ if 'install' in sys.argv or 'test' in sys.argv:
     funcpy = os.path.join(here, 'bqx/func.py')
     generate_funcpy(funcpy_in, funcpy)
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 __license__ = 'BSD License'
 __classifiers__ = [
     'Development Status :: 7 - Inactive',


### PR DESCRIPTION
I've forgotten to add long description in v0.4.1 :(

https://pypi.org/project/bqx/0.4.1/

<img width="1142" alt="image" src="https://github.com/fuller-inc/bqx/assets/1157344/e72334dc-cc08-4c22-98e7-9addb05531c6">

I'll do it in next release...
